### PR TITLE
Fix: lsclient environment reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build/
 *.tsbuildinfo
 .history/
 dag-packed.js
+dag-packed.js.map
 
 # env
 .env

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -111,7 +111,11 @@ export async function restartServer(
   const lsClient = lsClientInstance.getLanguageClient();
   if (lsClient) {
     traceInfo(`Server: Stop requested`);
-    await lsClient.stop();
+    try {
+      await lsClient.stop();
+    } catch (e) {
+      traceInfo(`Server: Stop failed - ${e}`, '\nContinuing to attempt to start');
+    }
     _disposables.forEach(d => d.dispose());
     _disposables = [];
   }


### PR DESCRIPTION
This pull request contains a fix for restarting the Language Server when the Language Server was never able to start.

changes:
- added `dag-packed.js.map` to `.gitignore` to remove build artifact from repository
- catches error caused by trying to stop a not running Language Server and allows the Server to attempt to restart the server.

This Language Server restart only happens when the python interpreter is changed, thus this fixes issues when an unsupported python interpreter is chosen. Before you would have to change the interpreter and then disable->restart->enable the extension for it to start the client again as the stop error was not handled.  Now, the extension will try to restart the server even if the server was not previously started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to exclude `dag-packed.js.map`.

- **Bug Fixes**
  - Improved error handling when restarting the server, ensuring it logs errors if the stop operation fails and continues the restart process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->