### PR TITLE
Fix: Error When Retrieving Server Information

### DIFF
--- a/bundled/tool/type_hints.py
+++ b/bundled/tool/type_hints.py
@@ -56,3 +56,23 @@ class RunArtifactResponse(TypedDict):
     update: str
     data: Dict[str, str]
     metadata: Dict[str, Any]
+
+class ZenmlStoreInfo(TypedDict):
+    id: str
+    version: str
+    debug: bool
+    deployment_type: str
+    database_type: str
+    secrets_store_type: str
+    auth_scheme: str
+    server_url: str
+    dashboard_url: str
+
+class ZenmlStoreConfig(TypedDict):
+    type: str
+    url: str
+    api_token: Union[str, None]
+
+class ZenmlServerInfoResp(TypedDict):
+    store_info: ZenmlStoreInfo
+    store_config: ZenmlStoreConfig

--- a/bundled/tool/type_hints.py
+++ b/bundled/tool/type_hints.py
@@ -76,3 +76,12 @@ class ZenmlStoreConfig(TypedDict):
 class ZenmlServerInfoResp(TypedDict):
     store_info: ZenmlStoreInfo
     store_config: ZenmlStoreConfig
+
+class ZenmlGlobalConfigResp(TypedDict):
+    user_id: str
+    user_email: str
+    analytics_opt_in: bool
+    version: str
+    active_stack_id: str
+    active_workspace_name: str
+    store: ZenmlStoreConfig

--- a/bundled/tool/zenml_wrappers.py
+++ b/bundled/tool/zenml_wrappers.py
@@ -12,10 +12,9 @@
 #  permissions and limitations under the License.
 """This module provides wrappers for ZenML configuration and operations."""
 
-import json
 import pathlib
 from typing import Any, Tuple, Union
-from type_hints import GraphResponse, ErrorResponse, RunStepResponse, RunArtifactResponse, ZenmlServerInfoResp
+from type_hints import GraphResponse, ErrorResponse, RunStepResponse, RunArtifactResponse, ZenmlServerInfoResp, ZenmlGlobalConfigResp
 from zenml_grapher import Grapher
 
 
@@ -99,19 +98,32 @@ class GlobalConfigWrapper:
             )
         self.gc.set_store(new_store_config)
 
-    def get_global_configuration(self) -> dict:
+    def get_global_configuration(self) -> ZenmlGlobalConfigResp:
         """Get the global configuration.
 
         Returns:
             dict: Global configuration.
         """
-        gc_dict = json.loads(self.gc.json(indent=2))
-        user_id = gc_dict.get("user_id", "")
 
-        if user_id and user_id.startswith("UUID('") and user_id.endswith("')"):
-            gc_dict["user_id"] = user_id[6:-2]
+        store_attr_name = (
+            "store_configuration" if hasattr(self.gc, "store_configuration") else "store"
+        )
 
-        return gc_dict
+        store_data = getattr(self.gc, store_attr_name)
+
+        return {
+            "user_id": str(self.gc.user_id),
+            "user_email": self.gc.user_email,
+            "analytics_opt_in": self.gc.analytics_opt_in,
+            "version": self.gc.version,
+            "active_stack_id": str(self.gc.active_stack_id),
+            "active_workspace_name": self.gc.active_workspace_name,
+            "store": {
+                "type": store_data.type,
+                "url": store_data.url,
+                "api_token": store_data.api_token if hasattr(store_data, "api_token") else None
+            }
+        }
 
 
 class ZenServerWrapper:
@@ -196,7 +208,7 @@ class ZenServerWrapper:
             "storeConfig": {
                 "type": store_config.type,
                 "url": store_config.url,
-                "api_token": store_config.api_token if "api_token" in store_config else None
+                "api_token": store_config.api_token if hasattr(store_config, "api_token") else None
             }
         }
 


### PR DESCRIPTION
This pull request contains changes to fix an issue with Pydantic not being compatible with a zenml library call at the moment. Original code was developed when zenml used pydantic 1.x, but currently uses 2.x and causes problems with retrieving server information. 

![image](https://github.com/user-attachments/assets/ed00cc00-e354-403d-800f-beb2363bd351)

Changes:
- Removed call to `json()` from object generated by `zenml.config.global_config.GlobalConfiguration().zen_store` and `zenml.config.global_config.GlobalConfiguration().get_store_info()` which would cause an error in the `getServerInfo` command (`ZenServerWrapper.get_server_info` method). Instead now builds the dict manually for the response instead of converting to json and back to a dict.
- Did the same for the `getGlobalConfig` command (`GlobalConfigWrapper.get_global_configuration`), though this is never called in the entire extension, just to be safe by not using the problematic function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced store configuration and server information retrieval with structured type hints.
  - Improved global configuration and server info methods to return detailed, user-centric information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->