### PR TITLE
Fix: 0.63 PipelineRun version removed.

### DIFF
--- a/bundled/tool/lsp_zenml.py
+++ b/bundled/tool/lsp_zenml.py
@@ -52,7 +52,7 @@ class ZenLanguageServer(LanguageServer):
             process = await asyncio.create_subprocess_exec(
                 self.python_interpreter,
                 "-c",
-                "import zenml",
+                "import zenml; print(zenml.__version__)",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/bundled/tool/zenml_grapher.py
+++ b/bundled/tool/zenml_grapher.py
@@ -96,5 +96,4 @@ class Grapher:
             "edges": self.edges,
             "status": self.run.body.status,
             "name": self.run.body.pipeline.name,
-            "version": self.run.body.pipeline.body.version,
         }

--- a/bundled/tool/zenml_wrappers.py
+++ b/bundled/tool/zenml_wrappers.py
@@ -328,7 +328,6 @@ class PipelineRunsWrapper:
                     "id": str(run.id),
                     "name": run.body.pipeline.name,
                     "status": run.body.status,
-                    "version": run.body.pipeline.body.version,
                     "stackName": run.body.stack.name,
                     "startTime": (
                         run.metadata.start_time.isoformat()
@@ -396,7 +395,6 @@ class PipelineRunsWrapper:
                 "id": str(run.id),
                 "name": run.body.pipeline.name,
                 "status": run.body.status,
-                "version": run.body.pipeline.body.version,
                 "stackName": run.body.stack.name,
                 "startTime": (
                     run.metadata.start_time.isoformat()
@@ -434,7 +432,7 @@ class PipelineRunsWrapper:
         """
         try:
             run_id = args[0]
-            run = self.client.get_pipeline_run(run_id, hydrate=True)
+            run = self.client.get_pipeline_run(run_id)
             graph = Grapher(run)
             graph.build_nodes_from_steps()
             graph.build_edges_from_steps()
@@ -485,7 +483,6 @@ class PipelineRunsWrapper:
                 "pipeline": {
                     "name": run.body.pipeline.name,
                     "status": run.body.status,
-                    "version": run.body.pipeline.body.version,
                 },
                 "cacheKey": step.metadata.cache_key,
                 "sourceCode": step.metadata.source_code,

--- a/src/commands/pipelines/DagRender.ts
+++ b/src/commands/pipelines/DagRender.ts
@@ -207,7 +207,7 @@ export default class DagRenderer extends WebviewBase {
     const graph = this.layoutDag(dagData);
     const svg = await this.drawDag(graph);
     const updateButton = dagData.status === 'running' || dagData.status === 'initializing';
-    const title = `${dagData.name} - v${dagData.version}`;
+    const title = `${dagData.name}`;
 
     // And set its HTML content
     panel.webview.html = this.getWebviewContent({

--- a/src/types/PipelineTypes.ts
+++ b/src/types/PipelineTypes.ts
@@ -25,7 +25,6 @@ export interface PipelineRun {
   id: string;
   name: string;
   status: string;
-  version: string;
   stackName: string;
   startTime: string;
   endTime: string;
@@ -67,7 +66,6 @@ export interface PipelineRunDag {
   edges: Array<DagEdge>;
   status: string;
   name: string;
-  version: string;
 }
 
 export type PipelineRunsResponse = PipelineRunsData | ErrorMessageResponse | VersionMismatchError;

--- a/src/views/activityBar/pipelineView/PipelineTreeItems.ts
+++ b/src/views/activityBar/pipelineView/PipelineTreeItems.ts
@@ -33,7 +33,7 @@ export class PipelineTreeItem extends vscode.TreeItem {
         : vscode.TreeItemCollapsibleState.Collapsed
     );
     this.tooltip = `${run.name} - Status: ${run.status}`;
-    this.description = `version: ${run.version}, status: ${run.status}`;
+    this.description = `status: ${run.status}`;
     this.iconPath = new vscode.ThemeIcon(PIPELINE_RUN_STATUS_ICONS[run.status]);
     this.children = children;
   }


### PR DESCRIPTION
This pull request has some bug fixes.

### Fixes
- Fixed ZenML installation detection to detect it not being installed (at least on linux). Was detecting it installed even if it wasn't.
- Removed all reference to the Pipeline Run Version in accordance with ZenML 0.63 client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the ZenML installation check to include version information for better debugging and compatibility checks.

- **Bug Fixes**
	- Removed version information from various output structures, including pipeline runs and graph titles, to streamline data representation.

- **Refactor**
	- Simplified the structure of interfaces and class properties by removing unnecessary version fields, focusing on essential attributes.

- **Chores**
	- Updated documentation and relevant code sections to reflect the removal of version information from descriptions and data outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->