### PR TITLE
Feature: Register OpenAI API key

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,6 +297,18 @@
         "title": "Restart LSP Server",
         "icon": "$(debug-restart)",
         "category": "ZenML Environment"
+      },
+      {
+        "command": "zenml.registerOpenAIAPIKey",
+        "title": "Register OpenAI API Key",
+        "icon": "$(add)",
+        "category": "ZenML Secrets"
+      },
+      {
+        "command": "zenml.deleteOpenAIAPIKey",
+        "title": "Delete OpenAI API Key",
+        "icon": "$(trash)",
+        "category": "ZenML Secrets"
       }
     ],
     "viewsContainers": {

--- a/package.json
+++ b/package.json
@@ -299,8 +299,8 @@
         "category": "ZenML Environment"
       },
       {
-        "command": "zenml.registerOpenAIAPIKey",
-        "title": "Register OpenAI API Key",
+        "command": "zenml.registerLLMAPIKey",
+        "title": "Register LLM API Key",
         "icon": "$(add)",
         "category": "ZenML Secrets"
       }

--- a/package.json
+++ b/package.json
@@ -303,12 +303,6 @@
         "title": "Register OpenAI API Key",
         "icon": "$(add)",
         "category": "ZenML Secrets"
-      },
-      {
-        "command": "zenml.deleteOpenAIAPIKey",
-        "title": "Delete OpenAI API Key",
-        "icon": "$(trash)",
-        "category": "ZenML Secrets"
       }
     ],
     "viewsContainers": {

--- a/src/commands/secrets/cmds.ts
+++ b/src/commands/secrets/cmds.ts
@@ -1,0 +1,56 @@
+// Copyright(c) ZenML GmbH 2024. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0(the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.See the License for the specific language governing
+// permissions and limitations under the License.
+
+import * as vscode from 'vscode';
+import type { ExtensionContext } from 'vscode';
+
+// TODO I don't think retrieval of an api key will live in here
+
+const registerOpenAIAPIKey = async (context: ExtensionContext) => {
+  let apiKey = await context.secrets.get('OPENAI_API_KEY');
+
+  if (apiKey) {
+    apiKey = await vscode.window.showInputBox({
+      prompt: 'OpenAI API Key already exists, enter a new value to update.',
+      password: true,
+    });
+  } else {
+    apiKey = await vscode.window.showInputBox({
+      prompt: 'Please enter your OpenAI API key',
+      password: true,
+    });
+  }
+
+  if (apiKey === undefined) {
+    return undefined;
+  }
+
+  await context.secrets.store('OPENAI_API_KEY', apiKey);
+  vscode.window.showInformationMessage('OpenAI API key stored successfully.');
+};
+
+const deleteOpenAIAPIKey = async (context: ExtensionContext) => {
+  const apiKey = await context.secrets.get('OPENAI_API_KEY');
+
+  if (apiKey === undefined) {
+    vscode.window.showInformationMessage('No OpenAI API key exists.');
+    return;
+  }
+  await context.secrets.delete('OPENAI_API_KEY');
+  vscode.window.showInformationMessage('OpenAI API key successfully removed.');
+};
+
+export const secretsCommands = {
+  registerOpenAIAPIKey,
+  deleteOpenAIAPIKey,
+};

--- a/src/commands/secrets/cmds.ts
+++ b/src/commands/secrets/cmds.ts
@@ -28,14 +28,13 @@ const registerLLMAPIKey = async (context: ExtensionContext) => {
 
   if (selectedOption === undefined) {
     vscode.window.showWarningMessage('API key input was canceled.');
-    return;
+    return undefined;
   }
 
   const model = selectedOption.label;
   const secretKey = `${model.toUpperCase()}_API_KEY`;
 
   let apiKey = await context.secrets.get(secretKey);
-  console.log(secretKey, apiKey);
 
   if (apiKey) {
     apiKey = await vscode.window.showInputBox({

--- a/src/commands/secrets/cmds.ts
+++ b/src/commands/secrets/cmds.ts
@@ -14,31 +14,50 @@
 import * as vscode from 'vscode';
 import type { ExtensionContext } from 'vscode';
 
-// TODO I don't think retrieval of an api key will live in here
+const registerLLMAPIKey = async (context: ExtensionContext) => {
+  const options: vscode.QuickPickItem[] = [
+    { label: 'Anthropic' },
+    { label: 'Gemini' },
+    { label: 'OpenAI' },
+  ];
 
-const registerOpenAIAPIKey = async (context: ExtensionContext) => {
-  let apiKey = await context.secrets.get('OPENAI_API_KEY');
+  const selectedOption = await vscode.window.showQuickPick(options, {
+    placeHolder: 'Please select an LLM.',
+    canPickMany: false,
+  });
+
+  if (selectedOption === undefined) {
+    vscode.window.showWarningMessage('API key input was canceled.');
+    return;
+  }
+
+  const model = selectedOption.label;
+  const secretKey = `${model.toUpperCase()}_API_KEY`;
+
+  let apiKey = await context.secrets.get(secretKey);
+  console.log(secretKey, apiKey);
 
   if (apiKey) {
     apiKey = await vscode.window.showInputBox({
-      prompt: 'OpenAI API Key already exists, enter a new value to update.',
+      prompt: `${model} API Key already exists, enter a new value to update.`,
       password: true,
     });
   } else {
     apiKey = await vscode.window.showInputBox({
-      prompt: 'Please enter your OpenAI API key',
+      prompt: `Please enter your ${model} API key`,
       password: true,
     });
   }
 
   if (apiKey === undefined) {
-    return undefined;
+    vscode.window.showWarningMessage('API key input was canceled.');
+    return;
   }
 
-  await context.secrets.store('OPENAI_API_KEY', apiKey);
-  vscode.window.showInformationMessage('OpenAI API key stored successfully.');
+  await context.secrets.store(secretKey, apiKey);
+  vscode.window.showInformationMessage(`${model} API key stored successfully.`);
 };
 
 export const secretsCommands = {
-  registerOpenAIAPIKey,
+  registerLLMAPIKey,
 };

--- a/src/commands/secrets/cmds.ts
+++ b/src/commands/secrets/cmds.ts
@@ -32,7 +32,7 @@ const registerLLMAPIKey = async (context: ExtensionContext) => {
   }
 
   const model = selectedOption.label;
-  const secretKey = `${model.toUpperCase()}_API_KEY`;
+  const secretKey = `zenml.${model.toLowerCase()}.key`;
 
   let apiKey = await context.secrets.get(secretKey);
 

--- a/src/commands/secrets/cmds.ts
+++ b/src/commands/secrets/cmds.ts
@@ -39,18 +39,6 @@ const registerOpenAIAPIKey = async (context: ExtensionContext) => {
   vscode.window.showInformationMessage('OpenAI API key stored successfully.');
 };
 
-const deleteOpenAIAPIKey = async (context: ExtensionContext) => {
-  const apiKey = await context.secrets.get('OPENAI_API_KEY');
-
-  if (apiKey === undefined) {
-    vscode.window.showInformationMessage('No OpenAI API key exists.');
-    return;
-  }
-  await context.secrets.delete('OPENAI_API_KEY');
-  vscode.window.showInformationMessage('OpenAI API key successfully removed.');
-};
-
 export const secretsCommands = {
   registerOpenAIAPIKey,
-  deleteOpenAIAPIKey,
 };

--- a/src/commands/secrets/registry.ts
+++ b/src/commands/secrets/registry.ts
@@ -28,8 +28,8 @@ export const registerSecretsCommands = (context: ExtensionContext) => {
   try {
     const registeredCommands = [
       registerCommand(
-        'zenml.registerOpenAIAPIKey',
-        async () => await secretsCommands.registerOpenAIAPIKey(context)
+        'zenml.registerLLMAPIKey',
+        async () => await secretsCommands.registerLLMAPIKey(context)
       ),
     ];
 

--- a/src/commands/secrets/registry.ts
+++ b/src/commands/secrets/registry.ts
@@ -1,0 +1,50 @@
+// Copyright(c) ZenML GmbH 2024. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0(the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.See the License for the specific language governing
+// permissions and limitations under the License.
+
+// TODO the registration of secrets commands should go in here, which is then imported into the ZenExtension file
+// In registry, the "register command thing is passed context (i.e. context.secrets) as an arg"
+
+import { secretsCommands } from './cmds';
+import { registerCommand } from '../../common/vscodeapi';
+import { ZenExtension } from '../../services/ZenExtension';
+import { ExtensionContext, commands } from 'vscode';
+
+/**
+ * Registers pipeline-related commands for the extension.
+ *
+ * @param {ExtensionContext} context - The context in which the extension operates, used for registering commands and managing their lifecycle.
+ */
+export const registerSecretsCommands = (context: ExtensionContext) => {
+  try {
+    const registeredCommands = [
+      registerCommand(
+        'zenml.registerOpenAIAPIKey',
+        async () => await secretsCommands.registerOpenAIAPIKey(context)
+      ),
+      registerCommand(
+        'zenml.deleteOpenAIAPIKey',
+        async () => await secretsCommands.deleteOpenAIAPIKey(context)
+      ),
+    ];
+
+    registeredCommands.forEach(cmd => {
+      context.subscriptions.push(cmd);
+      ZenExtension.commandDisposables.push(cmd);
+    });
+
+    commands.executeCommand('setContext', 'secretsCommandsRegistered', true);
+  } catch (error) {
+    console.error('Error registering pipeline commands:', error);
+    commands.executeCommand('setContext', 'secretsCommandsRegistered', false);
+  }
+};

--- a/src/commands/secrets/registry.ts
+++ b/src/commands/secrets/registry.ts
@@ -11,16 +11,13 @@
 // or implied.See the License for the specific language governing
 // permissions and limitations under the License.
 
-// TODO the registration of secrets commands should go in here, which is then imported into the ZenExtension file
-// In registry, the "register command thing is passed context (i.e. context.secrets) as an arg"
-
 import { secretsCommands } from './cmds';
 import { registerCommand } from '../../common/vscodeapi';
 import { ZenExtension } from '../../services/ZenExtension';
 import { ExtensionContext, commands } from 'vscode';
 
 /**
- * Registers pipeline-related commands for the extension.
+ * Registers secrets related commands for the extension.
  *
  * @param {ExtensionContext} context - The context in which the extension operates, used for registering commands and managing their lifecycle.
  */
@@ -40,7 +37,7 @@ export const registerSecretsCommands = (context: ExtensionContext) => {
 
     commands.executeCommand('setContext', 'secretsCommandsRegistered', true);
   } catch (error) {
-    console.error('Error registering pipeline commands:', error);
+    console.error('Error registering secrets commands:', error);
     commands.executeCommand('setContext', 'secretsCommandsRegistered', false);
   }
 };

--- a/src/commands/secrets/registry.ts
+++ b/src/commands/secrets/registry.ts
@@ -31,10 +31,6 @@ export const registerSecretsCommands = (context: ExtensionContext) => {
         'zenml.registerOpenAIAPIKey',
         async () => await secretsCommands.registerOpenAIAPIKey(context)
       ),
-      registerCommand(
-        'zenml.deleteOpenAIAPIKey',
-        async () => await secretsCommands.deleteOpenAIAPIKey(context)
-      ),
     ];
 
     registeredCommands.forEach(cmd => {

--- a/src/common/vscodeapi.ts
+++ b/src/common/vscodeapi.ts
@@ -18,6 +18,7 @@ import {
   ConfigurationScope,
   Disposable,
   DocumentSelector,
+  ExtensionContext,
   languages,
   LanguageStatusItem,
   LogOutputChannel,
@@ -68,4 +69,15 @@ export function createLanguageStatusItem(
   selector: DocumentSelector
 ): LanguageStatusItem {
   return languages.createLanguageStatusItem(id, selector);
+}
+
+export async function getSecret(context: ExtensionContext, key: string) {
+  const secret = await context.secrets.get(key);
+
+  if (secret === undefined) {
+    console.error(`The requested secret with key '${key}' does not exist.`);
+    return;
+  }
+
+  return secret;
 }

--- a/src/common/vscodeapi.ts
+++ b/src/common/vscodeapi.ts
@@ -76,7 +76,7 @@ export async function getSecret(context: ExtensionContext, key: string) {
 
   if (secret === undefined) {
     console.error(`The requested secret with key '${key}' does not exist.`);
-    return;
+    return undefined;
   }
 
   return secret;

--- a/src/services/ZenExtension.ts
+++ b/src/services/ZenExtension.ts
@@ -17,6 +17,7 @@ import * as vscode from 'vscode';
 import { registerPipelineCommands } from '../commands/pipelines/registry';
 import { registerServerCommands } from '../commands/server/registry';
 import { registerStackCommands } from '../commands/stack/registry';
+import { registerSecretsCommands } from '../commands/secrets/registry';
 import { EXTENSION_ROOT_DIR } from '../common/constants';
 import { registerLogger, traceLog, traceVerbose } from '../common/log/logging';
 import {
@@ -73,6 +74,7 @@ export class ZenExtension {
     registerStackCommands,
     registerComponentCommands,
     registerPipelineCommands,
+    registerSecretsCommands,
   ];
 
   /**


### PR DESCRIPTION
This pull request adds the ability to register an OpenAI API secret using VSCode's `SecretStorage` API.

It adds one command to the command palette `Register OpenAI API Key`. You can use that to add/update your API key. It currently only supports OpenAI, but will be updated in the future to support other LLMs.

To retrieve the API key, import the async function `getSecret` from `src/common/vscodeapi.ts`. You have to pass it an `ExtensionContext` object as an argument, along with a string for whichever secret you want (for OpenAI it will be `'OPENAI_API_KEY'`). How exactly you get the `ExtensionContext` object is going to depend on how / where your code is executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced commands to register both OpenAI and Large Language Model (LLM) API keys within the application.
	- Enhanced functionality for securely managing API keys, including user prompts and storage in secret management.

- **Bug Fixes**
	- Improved error handling during command registration to ensure a more robust user experience.

- **Documentation**
	- Updated documentation for secrets management commands to enhance user understanding and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->