### PR TITLE
feat: add spell check workflow and configuration

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -8,4 +8,4 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v4
       - name: Spell Check Repo
-        uses: crate-ci/typos@v1.29.4
+        uses: crate-ci/typos@v1

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,6 @@
+---
 name: Spellcheck
 on: [pull_request]
-
 jobs:
   spellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,11 @@
+name: Spellcheck
+on: [pull_request]
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v4
+      - name: Spell Check Repo
+        uses: crate-ci/typos@v1.29.4

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default]
+locale = "en-us"

--- a/.typos.toml
+++ b/.typos.toml
@@ -2,5 +2,5 @@
 locale = "en-us"
 
 [default.extend-words]
-# Usage example:
+# Ignore list of words. Usage example:
 # teh = "teh"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,6 @@
 [default]
 locale = "en-us"
+
+[default.extend-words]
+# Usage example:
+# teh = "teh"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,16 @@ npm run test
 - **VSCode Debug Console**: Utilize the debug console in the VSCode development window for troubleshooting and inspecting values.
 - **Extension Host Logs**: Review the extension host logs for runtime errors or unexpected behavior.
 
+### Spellchecking
+
+The project uses [typos](https://github.com/crate-ci/typos) for spellchecking with a standardized configuration. Run the spellcheck script with the following command:
+
+```bash
+./scripts/spellcheck.sh
+```
+
+The script automatically uses the repository's default config file `.typos.toml` in the root of the repository. Custom configurations are not supported to ensure consistent spell checking across all contributions. All arguments passed to the script (except `-c/--config`) are forwarded directly to `typos`.
+
 ## Contributing Changes
 
 1. **Create a Branch**: Make your changes in a new git branch based on the `develop` branch.

--- a/bundled/tool/zenml_wrappers.py
+++ b/bundled/tool/zenml_wrappers.py
@@ -828,7 +828,7 @@ class StacksWrapper:
         try:
             self.client.delete_stack_component(id, component_type)
 
-            return {"mesage": f"Stack Component {id} successfully deleted"}
+            return {"message": f"Stack Component {id} successfully deleted"}
         except self.ZenMLBaseException as e:
             return {"error": str(e)}
     

--- a/scripts/spellcheck.sh
+++ b/scripts/spellcheck.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+show_help() {
+    echo "Usage: $(basename "$0") [OPTIONS] [CONFIG_PATH]"
+    echo
+    echo "If no config path is provided, the script will look for:"
+    echo "  - .typos.toml in current directory"
+    echo "  - .typos.toml in parent directory"
+    echo "  - If no config is found, will fall back to typos defaults"
+}
+
+# Enable help flag
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    show_help
+    exit 0
+fi
+
+if [ ! -z "$1" ]; then
+    if [ -f "$1" ]; then
+        echo "Using config: $1"
+        typos --config "$1"
+    else
+        echo "Warning: Config file not found at $1"
+        echo "Falling back to typos defaults..."
+        typos
+    fi
+elif [ -f ".typos.toml" ]; then
+    echo "Using config from current directory: .typos.toml"
+    typos --config ".typos.toml"
+elif [ -f "../.typos.toml" ]; then
+    echo "Using config from parent directory: ../.typos.toml"
+    typos --config "../.typos.toml"
+else
+    echo "No config file found, using typos defaults..."
+    typos
+fi

--- a/src/commands/stack/StackForm.ts
+++ b/src/commands/stack/StackForm.ts
@@ -80,7 +80,7 @@ export default class StackForm extends WebviewBase {
    * Opens a webview panel with a form to update a specified stack
    * @param {string} id The id of the specified stack
    * @param {string} name The current name of the specified stack
-   * @param {object} components The component settings of the sepcified stack
+   * @param {object} components The component settings of the specified stack
    */
   public async updateForm(id: string, name: string, components: { [type: string]: string }) {
     const panel = await this.display();

--- a/src/common/panels.ts
+++ b/src/common/panels.ts
@@ -86,7 +86,7 @@ export default class Panels {
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Secuirty-Policy" content="default-src 'none';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none';">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Loading</title>
     <style>

--- a/src/services/LSClient.ts
+++ b/src/services/LSClient.ts
@@ -234,10 +234,10 @@ export class LSClient {
   /**
    * Updates the language client.
    *
-   * @param {LanguageClient} updatedCLient The new language client.
+   * @param {LanguageClient} updatedClient The new language client.
    */
-  public updateClient(updatedCLient: LanguageClient): void {
-    this.client = updatedCLient;
+  public updateClient(updatedClient: LanguageClient): void {
+    this.client = updatedClient;
     this.setupNotificationListeners();
   }
 

--- a/src/test/python_tests/lsp_test_client/session.py
+++ b/src/test/python_tests/lsp_test_client/session.py
@@ -81,7 +81,7 @@ class LspSession(MethodDispatcher):
         self._thread_pool.submit(self._reader.listen, self._endpoint.consume)
         return self
 
-    def __exit__(self, typ, value, _tb):
+    def __exit__(self, exc_type, value, _tb):
         self.shutdown(True)
         try:
             self._sub.terminate()

--- a/src/test/python_tests/lsp_test_client/utils.py
+++ b/src/test/python_tests/lsp_test_client/utils.py
@@ -51,7 +51,7 @@ class PythonFile:
             py_file.write(self.contents)
         return self
 
-    def __exit__(self, typ, value, _tb):
+    def __exit__(self, exc_type, value, _tb):
         """Cleans up and deletes the python file."""
         os.unlink(self.fullpath)
 

--- a/src/test/python_tests/requirements.in
+++ b/src/test/python_tests/requirements.in
@@ -2,7 +2,7 @@
 # NOTE:
 # Use Python 3.8 or greater which ever is the minimum version of the python
 # you plan on supporting when creating the environment or using pip-tools.
-# Only run the commands below to manully upgrade packages in requirements.txt:
+# Only run the commands below to manually upgrade packages in requirements.txt:
 # 1) python -m pip install pip-tools
 # 2) pip-compile --generate-hashes --upgrade ./src/test/python_tests/requirements.in
 # If you are using nox commands to setup or build package you don't need to


### PR DESCRIPTION
Hey! Found this issue randomly and thought I'd make a quick PR to help out.

- Add `scripts/spellcheck.sh` to run `typos` command
- Create .typos.toml config file (only contains locale for now)
- Implement a basic GH action to run `crate-ci/typos@v1.29.4`

Let me know if you’d like me to:
- Add ignored paths in spellcheck/GH action
- Include additional configuration in `.typos.toml`
- Add documentation for local usage + installation of `typos`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a GitHub Actions workflow for spell checking on pull requests.
  - Introduced a spell-checking configuration file with US English locale.
  - Created a shell script to facilitate spell checking using the repository configuration.

- **Bug Fixes**
  - Corrected a typo in the response message for stack component deletion.
  - Fixed a typographical error in the content security policy declaration.
  - Updated a comment regarding manual package upgrades in the requirements file.

- **Documentation**
  - Updated the contributing guidelines to include spell-checking instructions.
  - Corrected documentation for the `updateForm` method parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->