### PR TITLE
Bump GitHub Actions to latest versions

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 20.x
         cache: npm
@@ -21,7 +21,7 @@ runs:
       with:
         python-version: '3.11'
     - name: Pip cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-lint-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Lint
         uses: ./.github/actions/lint
   build-and-test:
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get Extension Version
         id: get_version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: npm

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,6 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Spell Check Repo
         uses: crate-ci/typos@v1

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get Extension Version
         id: get_version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: npm
@@ -81,13 +81,13 @@ jobs:
           cat RELEASE_NOTES.md
           echo "=============================="
       - name: Upload Extension Package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: zenml-vscode-${{ steps.get_version.outputs.version }}
           path: zenml.vsix
           retention-days: 7
       - name: Upload Changelog
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: changelog-and-release-notes
           path: |


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from v4 to v6
- Bumps `actions/setup-node` from v4 to v6
- Bumps `actions/upload-artifact` from v4 to v6
- Bumps `actions/cache` from v4 to v5

## Why consolidate?
Instead of merging three separate Dependabot PRs (#175, #176, #177), this single PR updates all GitHub Actions at once, ensuring consistency across all workflow files and the composite lint action.

## Files updated
- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`
- `.github/workflows/test-publish.yml`
- `.github/workflows/spellcheck.yml`
- `.github/actions/lint/action.yml`

## Test plan
- [ ] CI passes on this PR
- [ ] Workflows function correctly after merge

Closes #175, #176, #177