### PR TITLE
Add concurrency rules to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main, develop]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,9 @@
 ---
 name: Spellcheck
 on: [pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   spellcheck:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,15 @@ nox --session tests         # Run Python LSP server tests (pytest)
 ./scripts/lint.sh
 ```
 
+### Commit & PR Messages
+Use plain, human-readable messages without conventional commit prefixes:
+- ✅ `Add concurrency rules to CI workflows`
+- ✅ `Fix @types/vscode version compatibility`
+- ❌ `chore: add concurrency rules to CI workflows`
+- ❌ `fix: @types/vscode version compatibility`
+
+Keep messages concise and descriptive of what changed.
+
 ### Packaging & Publishing
 ```bash
 npm run vsce-package        # Create zenml.vsix package


### PR DESCRIPTION
## Summary
- Add concurrency configuration to cancel in-progress workflow runs when new commits are pushed to the same branch or PR
- Add commit message style guidelines to CLAUDE.md (no conventional commit prefixes)

## Changes
- Add `concurrency` configuration to `ci.yml` and `spellcheck.yml`
- Add "Commit & PR Messages" section to CLAUDE.md recommending plain, human-readable messages

## Benefits
- Saves CI resources by cancelling redundant runs
- Faster feedback on latest changes
- Clear guidelines for consistent commit message style