### PR TITLE
Add zizmor security linting for GitHub Actions workflows

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
       with:
         node-version: 20.x
         cache: npm
@@ -17,11 +17,11 @@ runs:
       run: npm run format-check
       shell: bash
     - name: Install Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.11'
     - name: Pip cache
-      uses: actions/cache@v5
+      uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-lint-${{ hashFiles('**/requirements.txt') }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       all-dependencies:
         patterns:
           - '*'  # Groups ALL dependency updates into a single PR
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -21,3 +23,5 @@ updates:
       all-actions:
         patterns:
           - '*'  # Groups ALL GitHub Actions updates into a single PR
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
         with:
           persist-credentials: false
       - name: Lint
@@ -25,11 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b  # v7
       - name: Run zizmor
         run: uvx zizmor --format=github .
   build-and-test:
@@ -39,11 +39,11 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
         with:
           persist-credentials: false
       - name: Install Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6
         with:
           node-version: 20.x
           cache: npm
@@ -53,6 +53,6 @@ jobs:
       - name: Compile TS tests
         run: npm run pretest
       - name: Run headless test
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3  # v1
         with:
           run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
       - name: Lint
@@ -25,11 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7
       - name: Run zizmor
         run: uvx zizmor --format=github .
   build-and-test:
@@ -39,11 +39,11 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 20.x
           cache: npm
@@ -53,6 +53,6 @@ jobs:
       - name: Compile TS tests
         run: npm run pretest
       - name: Run headless test
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
         with:
           run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Run zizmor
         run: uvx zizmor --format=github .
   build-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   lint:
     name: Lint
@@ -14,8 +16,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Lint
         uses: ./.github/actions/lint
+  security-lint:
+    name: Security Lint Workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        run: uvx zizmor --format=github .
   build-and-test:
     needs: lint
     runs-on: ubuntu-latest
@@ -24,6 +38,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,16 @@ name: Publish VSCode Extension
 on:
   release:
     types: [created]
+permissions:
+  contents: write
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Get Extension Version
         id: get_version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,21 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
         with:
           persist-credentials: false
       - name: Get Extension Version
         id: get_version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
       - name: Install Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6
         with:
           node-version: 20.x
           cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Run headless tests
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3  # v1
         with:
           run: npm test
       - name: Build Extension
@@ -74,7 +74,7 @@ jobs:
           echo "${{ steps.get_version.outputs.version }}" > VERSION
       - name: Update GitHub Release
         if: success() && startsWith(github.ref, 'refs/tags/')
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b  # v1
         with:
           artifacts: zenml.vsix,VERSION
           bodyFile: RELEASE_NOTES.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,21 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
       - name: Get Extension Version
         id: get_version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 20.x
           cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Run headless tests
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
         with:
           run: npm test
       - name: Build Extension
@@ -74,7 +74,7 @@ jobs:
           echo "${{ steps.get_version.outputs.version }}" > VERSION
       - name: Update GitHub Release
         if: success() && startsWith(github.ref, 'refs/tags/')
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
         with:
           artifacts: zenml.vsix,VERSION
           bodyFile: RELEASE_NOTES.md

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,8 @@
 ---
 name: Spellcheck
 on: [pull_request]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -10,5 +12,7 @@ jobs:
     steps:
       - name: Checkout Actions Repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Spell Check Repo
         uses: crate-ci/typos@v1

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
       - name: Spell Check Repo
-        uses: crate-ci/typos@v1
+        uses: crate-ci/typos@65120634e79d8374d1aa2f27e54baa0c364fff5a # v1

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
         with:
           persist-credentials: false
       - name: Spell Check Repo
-        uses: crate-ci/typos@65120634e79d8374d1aa2f27e54baa0c364fff5a # v1
+        uses: crate-ci/typos@65120634e79d8374d1aa2f27e54baa0c364fff5a  # v1

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -9,21 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
       - name: Get Extension Version
         id: get_version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 20.x
           cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Run headless tests
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
         with:
           run: npm test
       - name: Build Extension
@@ -85,13 +85,13 @@ jobs:
           cat RELEASE_NOTES.md
           echo "=============================="
       - name: Upload Extension Package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: zenml-vscode-${{ steps.get_version.outputs.version }}
           path: zenml.vsix
           retention-days: 7
       - name: Upload Changelog
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: changelog-and-release-notes
           path: |

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -2,12 +2,16 @@
 name: Test VSCode Extension Release
 on:
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   test-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Get Extension Version
         id: get_version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -9,21 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
         with:
           persist-credentials: false
       - name: Get Extension Version
         id: get_version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
       - name: Install Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6
         with:
           node-version: 20.x
           cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Run headless tests
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3  # v1
         with:
           run: npm test
       - name: Build Extension
@@ -85,13 +85,13 @@ jobs:
           cat RELEASE_NOTES.md
           echo "=============================="
       - name: Upload Extension Package
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: zenml-vscode-${{ steps.get_version.outputs.version }}
           path: zenml.vsix
           retention-days: 7
       - name: Upload Changelog
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: changelog-and-release-notes
           path: |

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,12 +2,6 @@
 # https://docs.zizmor.sh/configuration/
 
 rules:
-  # Version tags (@v6) are acceptable for trusted actions in this repo.
-  # SHA pinning adds maintenance overhead without proportional security benefit
-  # for a VS Code extension project using well-known actions.
-  unpinned-uses:
-    disable: true
-
   # These template injections use internal step outputs derived from package.json,
   # not user-controlled input, so they're false positives for this codebase.
   template-injection:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,18 @@
+# Zizmor GitHub Actions security linter configuration
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  # Version tags (@v6) are acceptable for trusted actions in this repo.
+  # SHA pinning adds maintenance overhead without proportional security benefit
+  # for a VS Code extension project using well-known actions.
+  unpinned-uses:
+    disable: true
+
+  # These template injections use internal step outputs derived from package.json,
+  # not user-controlled input, so they're false positives for this codebase.
+  template-injection:
+    ignore:
+      - release.yml:58        # VERSION from steps.get_version.outputs.version
+      - release.yml:74        # VERSION from steps.get_version.outputs.version
+      - test-publish.yml:51   # version from steps.get_version.outputs.version
+      - test-publish.yml:70   # VERSION from steps.get_version.outputs.version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,12 @@ nox --session tests         # Run Python LSP server tests (pytest)
 ```
 
 ### Pre-Commit Checklist
-**IMPORTANT**: Always run linting before committing:
+**CRITICAL**: Always run the full lint script before committing AND pushing:
 ```bash
 ./scripts/lint.sh
 ```
+
+This runs ruff, mypy, eslint, prettier, and yamlfix. CI will fail if any of these checks fail, so **always run this locally first** to catch issues before pushing. The script will auto-fix many issues (like YAML formatting), so run it, review the changes, then commit.
 
 ### Git Workflow
 - **Base branch for PRs**: `develop` (not `main`)


### PR DESCRIPTION
## Summary

- Adds [zizmor](https://docs.zizmor.sh/) GitHub Actions security linter to the CI pipeline
- Configures zizmor to match our security posture (version tags OK, no SHA pinning required)
- Hardens all workflows with explicit permissions and credential controls

## Changes

| File | Changes |
|------|---------|
| `.github/zizmor.yml` | Config disabling `unpinned-uses` (SHA pinning overkill) and ignoring false-positive `template-injection` findings |
| `.github/dependabot.yml` | Added 7-day cooldown config (zizmor auto-fix) |
| `.github/workflows/ci.yml` | Added `permissions: contents: read`, `persist-credentials: false`, new `security-lint` job |
| `.github/workflows/release.yml` | Added `permissions: contents: write`, `persist-credentials: false` |
| `.github/workflows/spellcheck.yml` | Added `permissions: contents: read`, `persist-credentials: false` |
| `.github/workflows/test-publish.yml` | Added `permissions: contents: read`, `persist-credentials: false` |

## Test plan

- [ ] CI passes (including new zizmor security-lint job)
- [ ] Verify zizmor annotations appear on PR if any issues found