### PR TITLE
Disable setup-node auto-caching in release workflow (fixes Security Lint)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,10 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 20.x
-          cache: npm
+          # Explicitly disable auto-caching: setup-node v6 caches by default when
+          # package.json declares a packageManager, which would restore a shared
+          # (poisonable) Actions cache in the publishing job.
+          package-manager-cache: false
       - name: Install dependencies
         run: npm ci
       - name: Run headless tests

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -6,8 +6,8 @@ rules:
   # not user-controlled input, so they're false positives for this codebase.
   template-injection:
     ignore:
-      - release.yml:58        # VERSION from steps.get_version.outputs.version
-      - release.yml:74        # VERSION from steps.get_version.outputs.version
+      - release.yml:61        # VERSION from steps.get_version.outputs.version
+      - release.yml:77        # VERSION from steps.get_version.outputs.version
       - test-publish.yml:51   # version from steps.get_version.outputs.version
       - test-publish.yml:70   # VERSION from steps.get_version.outputs.version
 
@@ -16,10 +16,10 @@ rules:
   # worthwhile hardening step but tracked separately.
   secrets-outside-env:
     ignore:
-      - release.yml:53        # VSCE_PAT used in publish step
+      - release.yml:56        # VSCE_PAT used in publish step
 
   # ncipollo/release-action handles artifact upload + body update atomically;
   # replacing with gh release is a nice cleanup but not a security issue.
   superfluous-actions:
     ignore:
-      - release.yml:77        # ncipollo/release-action for GitHub Release
+      - release.yml:80        # ncipollo/release-action for GitHub Release


### PR DESCRIPTION
## What

- **`release.yml`** — set `package-manager-cache: false` on the `actions/setup-node` step in the release/publish job (replacing the old `cache: npm`).
- **`zizmor.yml`** — renumber the existing `release.yml` ignores (the added lines shifted them). No new ignore needed.

## Why

The **Security Lint (zizmor)** check failed on *every* PR because of a pre-existing cache-poisoning finding on `release.yml`. `ci.yml` populates an npm cache (keyed on the `package-lock.json` hash) on every PR/push; the release job used the same key, so it could restore a poisoned/stale cache and bake it into the `.vsix` published to the marketplace with `VSCE_PAT` — with no CI warning.

**Why not just remove `cache: npm`:** `setup-node@v6` caches *automatically* — `package-manager-cache` defaults to `true` and turns on whenever `package.json` declares a `packageManager` or `devEngines.packageManager` of npm ([action.yml](https://github.com/actions/setup-node/blob/v6/action.yml)). This repo has no such field today, so caching is off — but a routine future `package.json` change (e.g. adding `packageManager` for corepack) would silently re-enable the cache in the publishing job. Setting `package-manager-cache: false` disables it explicitly and permanently.

Credit to the review bot for catching both the shared-cache risk and this auto-cache trapdoor.

## Result

With caching explicitly disabled, zizmor no longer reports the finding — so it's **resolved, not suppressed** (no `cache-poisoning` ignore). `uvx zizmor --format=github .` exits 0 (was 14); `yamlfix --check` passes.