### PR TITLE
Correct stale action version comments and ignore `.worktrees/`

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -17,7 +17,7 @@ runs:
       run: npm run format-check
       shell: bash
     - name: Install Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.11'
     - name: Pip cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v7
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
       - name: Run zizmor
         run: uvx zizmor --format=github .
   build-and-test:
@@ -43,7 +43,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 20.x
           cache: npm
@@ -53,6 +53,6 @@ jobs:
       - name: Compile TS tests
         run: npm run pretest
       - name: Run headless test
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3  # v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3  # v1.0.1
         with:
           run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,17 @@ jobs:
         id: get_version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
       - name: Install Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 20.x
-          # Explicitly disable auto-caching: setup-node v6 caches by default when
+          # Explicitly disable auto-caching: setup-node v6+ caches by default when
           # package.json declares a packageManager, which would restore a shared
           # (poisonable) Actions cache in the publishing job.
           package-manager-cache: false
       - name: Install dependencies
         run: npm ci
       - name: Run headless tests
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3  # v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3  # v1.0.1
         with:
           run: npm test
       - name: Build Extension
@@ -77,7 +77,7 @@ jobs:
           echo "${{ steps.get_version.outputs.version }}" > VERSION
       - name: Update GitHub Release
         if: success() && startsWith(github.ref, 'refs/tags/')
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
           artifacts: zenml.vsix,VERSION
           bodyFile: RELEASE_NOTES.md

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Spell Check Repo
-        uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14  # v1
+        uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14  # v1.48.0

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -16,14 +16,14 @@ jobs:
         id: get_version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
       - name: Install Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 20.x
           cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Run headless tests
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3  # v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3  # v1.0.1
         with:
           run: npm test
       - name: Build Extension

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ design/
 .bv/
 .claude/
 .zen/
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
Dependabot bumps the pinned SHAs of GitHub Actions but leaves the trailing `# vX` comment alone, so two comments had drifted away from what is actually pinned:

| Action | Comment said | SHA actually is |
|---|---|---|
| `actions/setup-node` | `# v6` | **v7.0.0** |
| `astral-sh/setup-uv` | `# v7` | **v8.3.2** |

Since the comment is the only human-readable clue about which release a 40-character SHA refers to, a wrong comment is worse than no comment — anyone auditing the pins would conclude we are still on setup-node v6.

While fixing those, the remaining vague `# v1` / `# v5` comments are expanded to exact tags, matching the already-precise `actions/checkout` and `actions/upload-artifact` lines and what `pinact run` writes:

| Action | Before | After |
|---|---|---|
| `coactions/setup-xvfb` | `# v1` | `# v1.0.1` |
| `ncipollo/release-action` | `# v1` | `# v1.21.0` |
| `crate-ci/typos` | `# v1` | `# v1.48.0` |
| `actions/setup-python` | `# v5` | `# v5.6.0` |

Every version was resolved against the GitHub tags API rather than assumed.

**No SHA is changed** — verified by diffing the sorted `uses:` lines before and after, which are identical. This PR cannot alter which action code runs.

Also:
- Updates the prose comment in `release.yml` that explained the `package-manager-cache: false` setting in terms of "setup-node v6" (now "v6+"). The input still exists in v7, so the protection added in #263 is intact.
- Adds `.worktrees/` to `.gitignore` for local git worktrees.

### Testing
`yamlfix --check` and `zizmor` both pass. Node-based lint was not run locally (an unrelated TLS issue blocks installing the `svg-pan-zoom` git dependency on this machine); CI covers it.